### PR TITLE
removes extra content from each resource block which was causing dupl…

### DIFF
--- a/resource-import/import.tf
+++ b/resource-import/import.tf
@@ -1,30 +1,5 @@
 resource "aws_vpc" "cluster_vpc" {
-  cidr_block       = var.cidr_blocks
-  instance_tenancy = "default"
-  enable_dns_support = true
-  enable_dns_hostnames = true
-
-  tags = merge(
-  var.default_tags,
-    map(
-    "Name", "${var.cluster_name}",
-    "kubernetes.io/cluster/${var.cluster_name}", "owned"
-    )
-  )
 }
 
 resource "aws_route53_zone" "private_zone" {
-  name =  "${var.cluster_name}.${var.cluster_domain}"
-  vpc {
-    vpc_id =  data.aws_vpc.cluster_vpc.id
-  }
-  force_destroy = "true"
-
-  tags =  merge(
-  var.default_tags,
-  map(
-    "Name",  "${var.cluster_name}.${var.cluster_domain}",
-    "kubernetes.io/cluster/${var.cluster_name}", "owned"
-    )
-  )
 }


### PR DESCRIPTION
I tested this with: `terraform import aws_vpc.cluster_vpc <vpc_id>` and verified that the vpc was being imported and not created. 

I also tested the route53 zone with `terraform import aws_route53_zone.private_zone <zone_id>` and verified that the zone was in fact imported and not re-created.