### PR TITLE
Update route53.tf

### DIFF
--- a/route53/route53.tf
+++ b/route53/route53.tf
@@ -14,27 +14,3 @@ resource "aws_route53_record" "api" {
   //records = [data.aws_lb.control_plane_int.dns_name]
   ttl = 300
 }
-
-resource "aws_route53_record" "etcd_srv" {
-  allow_overwrite = "true"
-  name = "_etcd-server-ssl._tcp"
-  type = "SRV"
-  zone_id = data.aws_route53_zone.private_zone.zone_id
-  records = [
-    "0 10 2380 etcd-0.${var.cluster_domain}",
-    "0 10 2380 etcd-1.${var.cluster_domain}",
-    "0 10 2380 etcd-2.${var.cluster_domain}"
-  ]
-  ttl = 300
-}
-
-resource "aws_route53_record" "etcd_a_nodes" {
-  count = 3
-  type    = "A"
-  ttl     = "60"
-  allow_overwrite = true
-//change lookup to private_zone - jrickard
-  zone_id = data.aws_route53_zone.private_zone.id
-  name    = "etcd-${count.index}.${var.cluster_domain }"
-  records = ["${data.terraform_remote_state.control-plane.outputs.master_private_ips[count.index]}"]
-}


### PR DESCRIPTION
Updating to reflect 4.6 OCP. ETCD records were a mechism used in 4.5 and below to allow the inital connection between the bootstrap and master nodes. This has been replaced in 4.6 by the API Load balancer entry point.